### PR TITLE
Add layer support (with toggling through commands) and change filtering logic

### DIFF
--- a/src/main/java/valoeghese/uniqueorigins/Uniqueorigins.java
+++ b/src/main/java/valoeghese/uniqueorigins/Uniqueorigins.java
@@ -29,6 +29,8 @@ import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.Identifier;
 import net.minecraft.world.World;
 
+import java.util.List;
+
 public class Uniqueorigins implements ModInitializer {
 	public static final Logger LOGGER = LogManager.getLogger("Uniqueorigins");
 	private static final String ID = "uniqueorigindata";
@@ -48,28 +50,23 @@ public class Uniqueorigins implements ModInitializer {
 
 	public interface UniquifierProperties {
 		/**
-		 * @return the lowest count of any origin.
+		 *
+		 * @param layer the given layer
+		 * @param origins the list of origins on the layer
+		 * @return the filtered list of origins with saturated origins removed
 		 */
-		int getMinOriginCount();
-		/**
-		 * @return the highest count of any origin.
-		 */
-		int getMaxOriginCount();
-		/**
-		 * Retrieves the count of a given origin.
-		 * @param identifier the given origin
-		 * @return the number of players with that origin
-		 */
-		int getOriginCount(Identifier identifier);
+		List<Identifier> filter(Identifier layer, List<Identifier> origins);
 		/**
 		 * Increments the count for the specified origin
+		 * @param layer the layer to increment the count for
 		 * @param origin the origin to increment the count for
 		 */
-		void addOriginCount(Identifier origin);
+		void incrementOriginCount(Identifier layer, Identifier origin);
 		/**
 		 * Decrement the count for the specified origin
+		 * @param layer the layer to decrement the count for
 		 * @param origin the origin to decrement the count for
 		 */
-		void removeOriginCount(Identifier origin);
+		void decrementOriginCount(Identifier layer, Identifier origin);
 	}
 }

--- a/src/main/java/valoeghese/uniqueorigins/Uniqueorigins.java
+++ b/src/main/java/valoeghese/uniqueorigins/Uniqueorigins.java
@@ -52,10 +52,11 @@ public class Uniqueorigins implements ModInitializer {
 		/**
 		 *
 		 * @param layer the given layer
-		 * @param origins the list of origins on the layer
+		 * @param conditionedOrigins the list of conditioned origins to filter
+		 * @param layerOrigins the list of origins on the layer
 		 * @return the filtered list of origins with saturated origins removed
 		 */
-		List<Identifier> filter(Identifier layer, List<Identifier> origins);
+		List<Identifier> filter(Identifier layer, List<Identifier> conditionedOrigins, List<Identifier> layerOrigins);
 		/**
 		 * Increments the count for the specified origin
 		 * @param layer the layer to increment the count for

--- a/src/main/java/valoeghese/uniqueorigins/Uniqueorigins.java
+++ b/src/main/java/valoeghese/uniqueorigins/Uniqueorigins.java
@@ -19,6 +19,8 @@
 
 package valoeghese.uniqueorigins;
 
+import net.fabricmc.fabric.api.command.v1.CommandRegistrationCallback;
+import net.minecraft.text.Text;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -30,6 +32,8 @@ import net.minecraft.util.Identifier;
 import net.minecraft.world.World;
 
 import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 
 public class Uniqueorigins implements ModInitializer {
 	public static final Logger LOGGER = LogManager.getLogger("Uniqueorigins");
@@ -38,6 +42,9 @@ public class Uniqueorigins implements ModInitializer {
 	@Override
 	public void onInitialize() {
 		LOGGER.info("Making sure your origins will be more... unique~");
+		CommandRegistrationCallback.EVENT.register((dispatcher, dedicated) -> {
+			UniqueoriginsCommand.register(dispatcher);
+		});
 	}
 
 	public static UniquifierProperties getOriginData(MinecraftServer server) {
@@ -50,7 +57,32 @@ public class Uniqueorigins implements ModInitializer {
 
 	public interface UniquifierProperties {
 		/**
-		 *
+		 * Tests whether the filter is active for a layer
+		 * @param layer the given layer
+		 * @param feedback a reference to the chat feedback function
+		 * @param error a reference to the chat error feedback function
+		 * @return whether the filter is on (1) or off (0)
+		 */
+		int getFilter(Identifier layer, BiConsumer<Text, Boolean> feedback, Consumer<Text> error);
+		/**
+		 * Activates/deactivates the filter for a layer
+		 * @param layer the given layer
+		 * @param value whether that layer should now be active
+		 * @param feedback a reference to the chat feedback function
+		 * @param error a reference to the chat error feedback function
+		 * @return the input value
+		 */
+		int setFilter(Identifier layer, boolean value, BiConsumer<Text, Boolean> feedback, Consumer<Text> error);
+		/**
+		 * Toggles the filter for a layer
+		 * @param layer the given layer
+		 * @param feedback a reference to the chat feedback function
+		 * @param error a reference to the chat error feedback function
+		 * @return the input value
+		 */
+		int toggleFilter(Identifier layer, BiConsumer<Text, Boolean> feedback, Consumer<Text> error);
+		/**
+		 * Filters out saturated origins from a list
 		 * @param layer the given layer
 		 * @param conditionedOrigins the list of conditioned origins to filter
 		 * @param layerOrigins the list of origins on the layer

--- a/src/main/java/valoeghese/uniqueorigins/UniqueoriginsCommand.java
+++ b/src/main/java/valoeghese/uniqueorigins/UniqueoriginsCommand.java
@@ -1,0 +1,55 @@
+package valoeghese.uniqueorigins;
+
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.arguments.BoolArgumentType;
+import io.github.apace100.origins.command.LayerArgument;
+import io.github.apace100.origins.origin.OriginLayer;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.command.ServerCommandSource;
+
+import static net.minecraft.server.command.CommandManager.argument;
+import static net.minecraft.server.command.CommandManager.literal;
+
+// Inspired by Apace's command registries
+
+public class UniqueoriginsCommand {
+
+    public static void register(CommandDispatcher<ServerCommandSource> dispatcher){
+        dispatcher.register(
+            literal("uniqueorigins").requires(cs -> cs.hasPermissionLevel(2))
+                .then(literal("layer")
+                    .then(argument("layer", LayerArgument.layer())
+                        .then(literal("filter")
+                            .then(literal("get")
+                                .executes(
+                                    command -> Uniqueorigins.getOriginData(command.getSource().getMinecraftServer()).getFilter(
+                                        command.getArgument("layer", OriginLayer.class).getIdentifier(),
+                                        command.getSource()::sendFeedback, command.getSource()::sendError
+                                    )
+                                )
+                            )
+                            .then(literal("set")
+                                .then(argument("active", BoolArgumentType.bool())
+                                    .executes(
+                                        command -> Uniqueorigins.getOriginData(command.getSource().getMinecraftServer()).setFilter(
+                                            command.getArgument("layer", OriginLayer.class).getIdentifier(),
+                                            command.getArgument("active", Boolean.class),
+                                            command.getSource()::sendFeedback, command.getSource()::sendError
+                                        )
+                                    )
+                                )
+                            )
+                            .then(literal("toggle")
+                                .executes(
+                                    command -> Uniqueorigins.getOriginData(command.getSource().getMinecraftServer()).toggleFilter(
+                                        command.getArgument("layer", OriginLayer.class).getIdentifier(),
+                                        command.getSource()::sendFeedback, command.getSource()::sendError
+                                    )
+                                )
+                            )
+                        )
+                    )
+                )
+        );
+    }
+}

--- a/src/main/java/valoeghese/uniqueorigins/mixin/MixinOriginLayer.java
+++ b/src/main/java/valoeghese/uniqueorigins/mixin/MixinOriginLayer.java
@@ -46,7 +46,7 @@ public abstract class MixinOriginLayer implements HackedOriginLayer {
 			@SuppressWarnings("ConstantConditions")
 			UniquifierProperties properties = Uniqueorigins.getOriginData(entity.getServer());
 			info.setReturnValue(
-				properties.filter(this.getIdentifier(), info.getReturnValue())
+				properties.filter(this.getIdentifier(), info.getReturnValue(), this.getOrigins())
 			);
 		}
 	}
@@ -67,6 +67,8 @@ public abstract class MixinOriginLayer implements HackedOriginLayer {
 	private boolean autoChooseIfNoChoice;
 
 	@Shadow public abstract Identifier getIdentifier();
+
+	@Shadow public abstract List<Identifier> getOrigins();
 
 	@Override
 	public void writeFirstLogin(PlayerEntity player, PacketByteBuf buffer) {
@@ -90,7 +92,7 @@ public abstract class MixinOriginLayer implements HackedOriginLayer {
 			toWrite.add(
 					new ConditionedOrigin( // filter out the options
 							((AccessorConditionedOrigin) origin).getCondition(),
-							properties.filter(this.getIdentifier(), origin.getOrigins()))
+							properties.filter(this.getIdentifier(), origin.getOrigins(), this.getOrigins()))
 					);
 		}
 

--- a/src/main/java/valoeghese/uniqueorigins/mixin/MixinOriginLayer.java
+++ b/src/main/java/valoeghese/uniqueorigins/mixin/MixinOriginLayer.java
@@ -20,10 +20,7 @@
 package valoeghese.uniqueorigins.mixin;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
-import java.util.stream.Collector;
-import java.util.stream.Collectors;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -41,26 +38,16 @@ import valoeghese.uniqueorigins.Uniqueorigins.HackedOriginLayer;
 import valoeghese.uniqueorigins.Uniqueorigins.UniquifierProperties;
 
 @Mixin(value = OriginLayer.class, remap = false)
-public class MixinOriginLayer implements HackedOriginLayer {
-	private <E extends Collection<Identifier>> E filter(E identifiers, UniquifierProperties properties, Collector<Identifier, ?, E> collector) {
-		E result = identifiers.stream()
-				.filter(id -> shouldFilter(id, properties))
-				.collect(collector);
-		return result;
-	}
-
-	private boolean shouldFilter(Identifier id, UniquifierProperties properties) {
-		int originCount = properties.getOriginCount(id);
-		return originCount < properties.getMaxOriginCount() || originCount == properties.getMinOriginCount(); // if max and min are the same, special case keep it. I tried simpler implementations of this but it deletes every origin which is cringe
-	}
+public abstract class MixinOriginLayer implements HackedOriginLayer {
 
 	@Inject(at= @At("RETURN"), method = "getRandomOrigins", cancellable = true)
 	private void makeOriginsUniqueRandom(PlayerEntity entity, CallbackInfoReturnable<List<Identifier>> info) {
 		if (!entity.getEntityWorld().isClient()) {
+			@SuppressWarnings("ConstantConditions")
 			UniquifierProperties properties = Uniqueorigins.getOriginData(entity.getServer());
 			info.setReturnValue(
-					filter(info.getReturnValue(), properties, Collectors.toList())
-					);
+				properties.filter(this.getIdentifier(), info.getReturnValue())
+			);
 		}
 	}
 
@@ -79,6 +66,8 @@ public class MixinOriginLayer implements HackedOriginLayer {
 	@Shadow
 	private boolean autoChooseIfNoChoice;
 
+	@Shadow public abstract Identifier getIdentifier();
+
 	@Override
 	public void writeFirstLogin(PlayerEntity player, PacketByteBuf buffer) {
 		// Old code
@@ -89,16 +78,19 @@ public class MixinOriginLayer implements HackedOriginLayer {
 		buffer.writeBoolean(enabled);
 
 		// Replaced Code Starts Here ===================================
+
+		@SuppressWarnings("ConstantConditions")
 		UniquifierProperties properties = Uniqueorigins.getOriginData(player.getServer()); // get the properties from the server
 
 		List<ConditionedOrigin> toWrite = new ArrayList<>();
 
 		// Iterate for each conditioned origin and filter out :b:ad ones
+		//                                           comedy ---^
 		for (ConditionedOrigin origin : conditionedOrigins) {
 			toWrite.add(
 					new ConditionedOrigin( // filter out the options
 							((AccessorConditionedOrigin) origin).getCondition(),
-							filter(origin.getOrigins(), properties, Collectors.toList()))
+							properties.filter(this.getIdentifier(), origin.getOrigins()))
 					);
 		}
 

--- a/src/main/java/valoeghese/uniqueorigins/mixin/MixinPlayerOriginComponent.java
+++ b/src/main/java/valoeghese/uniqueorigins/mixin/MixinPlayerOriginComponent.java
@@ -51,12 +51,9 @@ public abstract class MixinPlayerOriginComponent {
 				@SuppressWarnings("ConstantConditions")
 				UniquifierProperties properties = Uniqueorigins.getOriginData(this.player.getServer());
 
-				if (oldOrigin != null) {
-					Uniqueorigins.LOGGER.info("Removing 1 from the unique origin count of " + oldOrigin.getIdentifier() + " on layer " + layer.getIdentifier());
+				if (oldOrigin != null)
 					properties.decrementOriginCount(layer.getIdentifier(), oldOrigin.getIdentifier());
-				}
 
-				Uniqueorigins.LOGGER.info("Adding 1 to the unique origin count of " + origin.getIdentifier() + " on layer " + layer.getIdentifier());
 				properties.incrementOriginCount(layer.getIdentifier(), origin.getIdentifier());
 			}
 		}

--- a/src/main/java/valoeghese/uniqueorigins/mixin/MixinPlayerOriginComponent.java
+++ b/src/main/java/valoeghese/uniqueorigins/mixin/MixinPlayerOriginComponent.java
@@ -35,7 +35,7 @@ import valoeghese.uniqueorigins.Uniqueorigins.UniquifierProperties;
 @Mixin(value = PlayerOriginComponent.class, remap = false)
 public abstract class MixinPlayerOriginComponent {
 	@Shadow
-	abstract Origin getOrigin(OriginLayer layer);
+	public abstract Origin getOrigin(OriginLayer layer);
 
 	@Shadow
 	private PlayerEntity player;
@@ -48,15 +48,16 @@ public abstract class MixinPlayerOriginComponent {
 			if(oldOrigin != origin) {
 				// now our actual code starts
 				// we edit our persistent state information to update who has what
+				@SuppressWarnings("ConstantConditions")
 				UniquifierProperties properties = Uniqueorigins.getOriginData(this.player.getServer());
 
 				if (oldOrigin != null) {
-					System.out.println("Removing from the unique origin count: " + oldOrigin.getIdentifier());
-					properties.removeOriginCount(oldOrigin.getIdentifier());
+					Uniqueorigins.LOGGER.info("Removing 1 from the unique origin count of " + oldOrigin.getIdentifier() + " on layer " + layer.getIdentifier());
+					properties.decrementOriginCount(layer.getIdentifier(), oldOrigin.getIdentifier());
 				}
 
-				System.out.println("Adding to the unique origin count: " + origin.getIdentifier());
-				properties.addOriginCount(origin.getIdentifier());
+				Uniqueorigins.LOGGER.info("Adding 1 to the unique origin count of " + origin.getIdentifier() + " on layer " + layer.getIdentifier());
+				properties.incrementOriginCount(layer.getIdentifier(), origin.getIdentifier());
 			}
 		}
 	}


### PR DESCRIPTION
*Should* be backwards-compatible.

The changes in the logic have the mod recalculate the minimum everytime, it's slower but it should allow the algorithms I mention in #2 to be used without making the task of keeping track of the minimum count more error-prone than it already is (stateless is better, we don't have to bend the code in 90 ways to keep the data sane). It also makes the program easier to understand imo.